### PR TITLE
refactor(functions): Create an ExpressFunction Data Type

### DIFF
--- a/functions/src/@types/index.d.ts
+++ b/functions/src/@types/index.d.ts
@@ -1,0 +1,7 @@
+import type { NextFunction, Request, Response } from "express";
+
+export type ExpressFunction<T = void> = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => T;

--- a/functions/src/modules/stpm/companies/createCompany.ts
+++ b/functions/src/modules/stpm/companies/createCompany.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const createCompany = (req: Request, res: Response, next: NextFunction) => {
+const createCompany: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/companies/deleteCompany.ts
+++ b/functions/src/modules/stpm/companies/deleteCompany.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const deleteCompany = (req: Request, res: Response, next: NextFunction) => {
+const deleteCompany: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/companies/getCompany.ts
+++ b/functions/src/modules/stpm/companies/getCompany.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const getCompany = (req: Request, res: Response, next: NextFunction) => {
+const getCompany: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/companies/getCompanyBenefits.ts
+++ b/functions/src/modules/stpm/companies/getCompanyBenefits.ts
@@ -1,10 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const getCompanyBenefits = (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
+const getCompanyBenefits: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/companies/listCompanies.ts
+++ b/functions/src/modules/stpm/companies/listCompanies.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const listCompanies = (req: Request, res: Response, next: NextFunction) => {
+const listCompanies: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/companies/updateCompany.ts
+++ b/functions/src/modules/stpm/companies/updateCompany.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const updateCompany = (req: Request, res: Response, next: NextFunction) => {
+const updateCompany: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/tiers/createCompany.ts
+++ b/functions/src/modules/stpm/tiers/createCompany.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const createTier = (req: Request, res: Response, next: NextFunction) => {
+const createTier: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/tiers/deleteCompany.ts
+++ b/functions/src/modules/stpm/tiers/deleteCompany.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const deleteTier = (req: Request, res: Response, next: NextFunction) => {
+const deleteTier: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/tiers/getCompany.ts
+++ b/functions/src/modules/stpm/tiers/getCompany.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const getTier = (req: Request, res: Response, next: NextFunction) => {
+const getTier: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/tiers/listCompanies.ts
+++ b/functions/src/modules/stpm/tiers/listCompanies.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const listTiers = (req: Request, res: Response, next: NextFunction) => {
+const listTiers: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };

--- a/functions/src/modules/stpm/tiers/updateCompany.ts
+++ b/functions/src/modules/stpm/tiers/updateCompany.ts
@@ -1,6 +1,6 @@
-import type { NextFunction, Request, Response } from "express";
+import type { ExpressFunction } from "../../../@types";
 
-const updateTier = (req: Request, res: Response, next: NextFunction) => {
+const updateTier: ExpressFunction = (req, res, next) => {
   res.status(200).send();
   next();
 };


### PR DESCRIPTION
This should streamline the amount of type definition declaration and reduce the number of imports required for each module and system.