### PR TITLE
fix(functions): Support Type Validator Enums and Dictionaries

### DIFF
--- a/@types/modules/stpm/companies.d.ts
+++ b/@types/modules/stpm/companies.d.ts
@@ -4,7 +4,7 @@ declare interface STPMCompanyUpdateRequest {
   companyWebsite?: string;
   companyAcronym?: string;
   sponsorTierId?: string;
-  overriddenBenefits?: { [key: string]: string };
+  overriddenBenefits?: STPMTierUpdateRequest;
 }
 
 declare interface STPMCompanyCreateRequest extends STPMCompanyUpdateRequest {
@@ -14,7 +14,7 @@ declare interface STPMCompanyCreateRequest extends STPMCompanyUpdateRequest {
 }
 
 declare interface STPMCompany extends STPMCompanyCreateRequest {
-  overriddenBenefits: { [key: string]: string };
+  overriddenBenefits: STPMTierUpdateRequest;
 }
 
 declare interface STPMCompanyList {

--- a/functions/src/@types/helper/typeValidator.d.ts
+++ b/functions/src/@types/helper/typeValidator.d.ts
@@ -24,5 +24,6 @@ declare type primitive =
   | "symbol"
   | "null"
   | "undefined"
+  | "emptystring"
   | "boolean"
   | "function";

--- a/functions/src/@types/helper/typeValidator.d.ts
+++ b/functions/src/@types/helper/typeValidator.d.ts
@@ -1,6 +1,6 @@
 declare interface ValidatorAdvancedTypeRules {
   rules: any;
-  type: "array" | "object";
+  type: "array" | "object" | "dictionary";
 }
 
 declare interface ValidatorObjectRules extends ValidatorAdvancedTypeRules {
@@ -13,6 +13,11 @@ declare interface ValidatorObjectRules extends ValidatorAdvancedTypeRules {
 declare interface ValidatorArrayRules extends ValidatorAdvancedTypeRules {
   rules: ValidatorAllowedTypes;
   type: "array";
+}
+
+declare interface ValidatorDictionaryRules extends ValidatorAdvancedTypeRules {
+  rules: ValidatorAllowedTypes;
+  type: "dictionary";
 }
 
 declare type ValidatorAllowedTypes = (primitive | ValidatorAdvancedTypeRules)[];

--- a/functions/src/@types/helper/typeValidator.d.ts
+++ b/functions/src/@types/helper/typeValidator.d.ts
@@ -1,6 +1,6 @@
 declare interface ValidatorAdvancedTypeRules {
   rules: any;
-  type: "array" | "object" | "dictionary";
+  type: "array" | "object" | "dictionary" | "enum";
 }
 
 declare interface ValidatorObjectRules extends ValidatorAdvancedTypeRules {
@@ -18,6 +18,11 @@ declare interface ValidatorArrayRules extends ValidatorAdvancedTypeRules {
 declare interface ValidatorDictionaryRules extends ValidatorAdvancedTypeRules {
   rules: ValidatorAllowedTypes;
   type: "dictionary";
+}
+
+declare interface ValidatorEnumRules extends ValidatorAdvancedTypeRules {
+  rules: any[]; // Allowed values
+  type: "enum";
 }
 
 declare type ValidatorAllowedTypes = (primitive | ValidatorAdvancedTypeRules)[];

--- a/functions/src/helpers/typeValidator.test.ts
+++ b/functions/src/helpers/typeValidator.test.ts
@@ -409,6 +409,47 @@ test("validateAttribute fails to match on no object handlers", () => {
   expect(typeMismatch[0].includes("was object")).toBe(true);
 });
 
+test("validateAttribute matches empty string when allowed", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateAttribute(
+    "testAttribute",
+    "",
+    ["string", "emptystring"],
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(typeMismatch).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
+});
+
+test("validateAttribute fails on empty string when now allowed", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateAttribute(
+    "testAttribute",
+    "",
+    ["string"],
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
+  expect(typeMismatch.length).toBe(1);
+  expect(typeMismatch[0].includes("testAttribute")).toBe(true);
+  expect(typeMismatch[0].includes("[string]")).toBe(true);
+  expect(typeMismatch[0].includes("was emptystring")).toBe(true);
+});
+
 // -----------------------------------------------------------------------------
 // getAdvancedTypeHandlers
 // -----------------------------------------------------------------------------

--- a/functions/src/helpers/typeValidator.test.ts
+++ b/functions/src/helpers/typeValidator.test.ts
@@ -27,6 +27,11 @@ const checkDictionaryRule: ValidatorDictionaryRules = {
   rules: ["string", "number"],
 };
 
+const checkEnumRule: ValidatorEnumRules = {
+  type: "enum",
+  rules: ["small", "medium", "large"],
+};
+
 const primitiveCheckRules: ValidatorAllowedTypes = [
   "undefined",
   "null",
@@ -551,6 +556,66 @@ test("validateAttribute fails on empty string when now allowed", () => {
   expect(typeMismatch[0].includes("testAttribute")).toBe(true);
   expect(typeMismatch[0].includes("[string]")).toBe(true);
   expect(typeMismatch[0].includes("was emptystring")).toBe(true);
+});
+
+test("validateAttribute succeeds on enum match", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateAttribute(
+    "testAttribute",
+    "small",
+    [checkEnumRule],
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(typeMismatch).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
+});
+
+test("validateAttribute fails on enum mismatch", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateAttribute(
+    "testAttribute",
+    "test",
+    [checkEnumRule],
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
+  expect(typeMismatch.length).toBe(1);
+  expect(typeMismatch[0].includes("testAttribute")).toBe(true);
+  expect(typeMismatch[0].includes("[enum<small, medium, large>]")).toBe(true);
+  expect(typeMismatch[0].includes("was string")).toBe(true);
+});
+
+test("validateAttribute succeeds on enum mismatch but primative match", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateAttribute(
+    "testAttribute",
+    "test",
+    [checkEnumRule, "string"],
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(typeMismatch).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
 });
 
 // -----------------------------------------------------------------------------

--- a/functions/src/helpers/typeValidator.test.ts
+++ b/functions/src/helpers/typeValidator.test.ts
@@ -8,10 +8,12 @@ const checkArrayRule1: ValidatorArrayRules = {
   type: "array",
   rules: ["string", "number"],
 };
+
 const checkArrayRule2: ValidatorArrayRules = {
   type: "array",
   rules: ["boolean"],
 };
+
 const checkObjectRule: ValidatorObjectRules = {
   type: "object",
   rules: {
@@ -19,6 +21,12 @@ const checkObjectRule: ValidatorObjectRules = {
     test2: { rules: ["number"], required: true },
   },
 };
+
+const checkDictionaryRule: ValidatorDictionaryRules = {
+  type: "dictionary",
+  rules: ["string", "number"],
+};
+
 const primitiveCheckRules: ValidatorAllowedTypes = [
   "undefined",
   "null",
@@ -26,6 +34,7 @@ const primitiveCheckRules: ValidatorAllowedTypes = [
   "number",
   "boolean",
 ];
+
 const checkRules = primitiveCheckRules.concat(
   checkArrayRule1,
   checkArrayRule2,
@@ -115,15 +124,15 @@ test("validateObject fails on extra attribute", () => {
 });
 
 // -----------------------------------------------------------------------------
-// validateArray
+// validateArrayOrDictionary
 // -----------------------------------------------------------------------------
 
-test("validateArray matches empty array", () => {
+test("validateArrayOrDictionary matches empty array", () => {
   const expectedButMissing: string[] = [];
   const typeMismatch: string[] = [];
   const unexpectedAttribute: string[] = [];
 
-  testFunctions.validateArray(
+  testFunctions.validateArrayOrDictionary(
     "testAttribute",
     [],
     checkArrayRule1.rules,
@@ -137,12 +146,12 @@ test("validateArray matches empty array", () => {
   expect(unexpectedAttribute).toStrictEqual([]);
 });
 
-test("validateArray matches if all match", () => {
+test("validateArrayOrDictionary matches if all array entries match", () => {
   const expectedButMissing: string[] = [];
   const typeMismatch: string[] = [];
   const unexpectedAttribute: string[] = [];
 
-  testFunctions.validateArray(
+  testFunctions.validateArrayOrDictionary(
     "testAttribute",
     ["test", 0, "anotherTest", 1],
     checkArrayRule1.rules,
@@ -156,12 +165,12 @@ test("validateArray matches if all match", () => {
   expect(unexpectedAttribute).toStrictEqual([]);
 });
 
-test("validateArray fails to match on partial mismatch", () => {
+test("validateArrayOrDictionary fails to match on array partial mismatch", () => {
   const expectedButMissing: string[] = [];
   const typeMismatch: string[] = [];
   const unexpectedAttribute: string[] = [];
 
-  testFunctions.validateArray(
+  testFunctions.validateArrayOrDictionary(
     "testAttribute",
     ["test", 0, false, "anotherTest", 1, undefined],
     checkArrayRule1.rules,
@@ -177,6 +186,81 @@ test("validateArray fails to match on partial mismatch", () => {
   expect(typeMismatch[0].includes("[string, number]")).toBe(true);
   expect(typeMismatch[0].includes("was boolean")).toBe(true);
   expect(typeMismatch[1].includes("testAttribute[5]")).toBe(true);
+  expect(typeMismatch[1].includes("[string, number]")).toBe(true);
+  expect(typeMismatch[1].includes("was undefined")).toBe(true);
+});
+
+test("validateArrayOrDictionary matches empty dictionary", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateArrayOrDictionary(
+    "testAttribute",
+    {},
+    checkDictionaryRule.rules,
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(typeMismatch).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
+});
+
+test("validateArrayOrDictionary matches if all dictionary values match", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateArrayOrDictionary(
+    "testAttribute",
+    {
+      attribute1: "test",
+      attribute2: 0,
+      attribute3: "anotherTest",
+      attribute4: 1,
+    },
+    checkArrayRule1.rules,
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(typeMismatch).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
+});
+
+test("validateArrayOrDictionary fails to match on dictionary partial mismatch", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateArrayOrDictionary(
+    "testAttribute",
+    {
+      attribute1: "test",
+      attribute2: 0,
+      attribute3: false,
+      attribute4: "anotherTest",
+      attribute5: 1,
+      attribute6: undefined,
+    },
+    checkArrayRule1.rules,
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
+  expect(typeMismatch.length).toBe(2);
+  expect(typeMismatch[0].includes("testAttribute[attribute3]")).toBe(true);
+  expect(typeMismatch[0].includes("[string, number]")).toBe(true);
+  expect(typeMismatch[0].includes("was boolean")).toBe(true);
+  expect(typeMismatch[1].includes("testAttribute[attribute6]")).toBe(true);
   expect(typeMismatch[1].includes("[string, number]")).toBe(true);
   expect(typeMismatch[1].includes("was undefined")).toBe(true);
 });
@@ -289,7 +373,7 @@ test("validateAttribute fails to match on no primitive rule", () => {
   expect(typeMismatch[0].includes("was number")).toBe(true);
 });
 
-test("validateAttribute passes to validateArray on single array handler", () => {
+test("validateAttribute passes to validateArrayOrDictionary on single array handler", () => {
   const expectedButMissing: string[] = [];
   const typeMismatch: string[] = [];
   const unexpectedAttribute: string[] = [];
@@ -358,6 +442,25 @@ test("validateAttribute passes to validateObject on single object handler", () =
     "testAttribute",
     { test: "Hello World", test2: 0 },
     [checkObjectRule],
+    expectedButMissing,
+    typeMismatch,
+    unexpectedAttribute
+  );
+
+  expect(expectedButMissing).toStrictEqual([]);
+  expect(typeMismatch).toStrictEqual([]);
+  expect(unexpectedAttribute).toStrictEqual([]);
+});
+
+test("validateAttribute passes to validateArrayOrDictionary on single dictionary handler", () => {
+  const expectedButMissing: string[] = [];
+  const typeMismatch: string[] = [];
+  const unexpectedAttribute: string[] = [];
+
+  testFunctions.validateAttribute(
+    "testAttribute",
+    { test: "Hello World", test2: 0 },
+    [checkDictionaryRule],
     expectedButMissing,
     typeMismatch,
     unexpectedAttribute

--- a/functions/src/helpers/typeValidator.ts
+++ b/functions/src/helpers/typeValidator.ts
@@ -134,6 +134,8 @@ const validateAttribute = (
       ? "null"
       : Array.isArray(attributeValue)
       ? "array"
+      : attributeValue === ""
+      ? "emptystring"
       : typeof attributeValue;
 
   const arrayHandlers = getAdvancedTypeHandlers(

--- a/functions/src/modules/stpm/companies/createCompany.ts
+++ b/functions/src/modules/stpm/companies/createCompany.ts
@@ -5,6 +5,7 @@ import {
   requestBodyTypeValidator,
 } from "../../../helpers";
 import { uasPermissionSwitch } from "../../../systems/uas";
+import { validationRules as stpmTierUpdateValidationRules } from "../tiers/updateTier";
 
 const createCompany: ExpressFunction = (req, res, next) => {
   uasPermissionSwitch({
@@ -22,7 +23,7 @@ const validate: ExpressFunction = (req, res, next) => {
       companyWebsite: { rules: ["string", "emptystring"] },
       companyAcronym: { rules: ["string", "emptystring"] },
       sponsorTierId: { rules: ["string"], required: true },
-      //overriddenBenefits: { [key: string]: string }; TODO: Support Dictionary Advanced Types
+      overriddenBenefits: { rules: [stpmTierUpdateValidationRules] },
     },
   };
   requestBodyTypeValidator(req, res, next)(validationRules, execute);

--- a/functions/src/modules/stpm/companies/createCompany.ts
+++ b/functions/src/modules/stpm/companies/createCompany.ts
@@ -18,9 +18,9 @@ const validate: ExpressFunction = (req, res, next) => {
     rules: {
       companyId: { rules: ["string"], required: true },
       companyName: { rules: ["string"], required: true },
-      companyLogoUrl: { rules: ["string"]},
-      companyWebsite: { rules: ["string"]},
-      companyAcronym: { rules: ["string"]},
+      companyLogoUrl: { rules: ["string", "emptystring"] },
+      companyWebsite: { rules: ["string", "emptystring"] },
+      companyAcronym: { rules: ["string", "emptystring"] },
       sponsorTierId: { rules: ["string"], required: true },
       //overriddenBenefits: { [key: string]: string }; TODO: Support Dictionary Advanced Types
     },

--- a/functions/src/modules/stpm/companies/updateCompany.ts
+++ b/functions/src/modules/stpm/companies/updateCompany.ts
@@ -18,9 +18,9 @@ const validateOrganizer: ExpressFunction = (req, res, next) => {
     type: "object",
     rules: {
       companyName: { rules: ["string"] },
-      companyLogoUrl: { rules: ["string"] },
-      companyWebsite: { rules: ["string"] },
-      companyAcronym: { rules: ["string"] },
+      companyLogoUrl: { rules: ["string", "emptystring"] },
+      companyWebsite: { rules: ["string", "emptystring"] },
+      companyAcronym: { rules: ["string", "emptystring"] },
       sponsorTierId: { rules: ["string"] },
       // overriddenBenefits: { [key: string]: string }; TODO: Support Dictionary Advanced Types
     },

--- a/functions/src/modules/stpm/companies/updateCompany.ts
+++ b/functions/src/modules/stpm/companies/updateCompany.ts
@@ -5,6 +5,7 @@ import {
   requestBodyTypeValidator,
 } from "../../../helpers";
 import { uasPermissionSwitch } from "../../../systems/uas";
+import { validationRules as stpmTierUpdateValidationRules } from "../tiers/updateTier";
 
 const updateCompany: ExpressFunction = (req, res, next) => {
   uasPermissionSwitch({
@@ -22,7 +23,7 @@ const validateOrganizer: ExpressFunction = (req, res, next) => {
       companyWebsite: { rules: ["string", "emptystring"] },
       companyAcronym: { rules: ["string", "emptystring"] },
       sponsorTierId: { rules: ["string"] },
-      // overriddenBenefits: { [key: string]: string }; TODO: Support Dictionary Advanced Types
+      overriddenBenefits: { rules: [stpmTierUpdateValidationRules] },
     },
   };
   requestBodyTypeValidator(req, res, next)(validationRules, execute);
@@ -33,9 +34,9 @@ const validateSponsor: ExpressFunction = (req, res, next) => {
     type: "object",
     rules: {
       companyName: { rules: ["string"] },
-      companyLogoUrl: { rules: ["string"] },
-      companyWebsite: { rules: ["string"] },
-      companyAcronym: { rules: ["string"] },
+      companyLogoUrl: { rules: ["string", "emptystring"] },
+      companyWebsite: { rules: ["string", "emptystring"] },
+      companyAcronym: { rules: ["string", "emptystring"] },
     },
   };
   requestBodyTypeValidator(req, res, next)(validationRules, execute);

--- a/functions/src/modules/stpm/tiers/createTier.ts
+++ b/functions/src/modules/stpm/tiers/createTier.ts
@@ -19,12 +19,18 @@ const validate: ExpressFunction = (req, res, next) => {
       sponsorTierId: { rules: ["string"], required: true },
       sponsorTierName: { rules: ["string"], required: true },
       sponsorTierOrder: { rules: ["number"] },
-      logoSize: { rules: ["string"], required: true }, // TODO: Support Enum Advanced Types
+      logoSize: {
+        rules: [{ type: "enum", rules: ["xs", "sm", "m", "lg", "xl"] }],
+        required: true,
+      },
       sponsorshipExpo: { rules: ["boolean"], required: true },
       techTalk: { rules: ["boolean"], required: true },
       officeHours: { rules: ["boolean"], required: true },
       prizeBudget: { rules: ["number"], required: true },
-      attendeeData: { rules: ["string"], required: true }, // TODO: Support Enum Advanced Types
+      attendeeData: {
+        rules: [{ type: "enum", rules: ["none", "pre", "post"] }],
+        required: true,
+      },
       numberOfMentors: { rules: ["number"], required: true },
       numberOfRecruiters: { rules: ["number"], required: true },
       distributionOfSwag: { rules: ["boolean"], required: true },

--- a/functions/src/modules/stpm/tiers/createTier.ts
+++ b/functions/src/modules/stpm/tiers/createTier.ts
@@ -30,7 +30,9 @@ const validate: ExpressFunction = (req, res, next) => {
       distributionOfSwag: { rules: ["boolean"], required: true },
       openingSessionTalkLength: { rules: ["number"], required: true },
       closingSessionTalkLength: { rules: ["number"], required: true },
-      // otherBenefits: { [key: string]: string }; // TODO: Support Dictionary Advanced Types
+      otherBenefits: {
+        rules: [{ type: "dictionary", rules: ["string", "number"] }],
+      },
     },
   };
   requestBodyTypeValidator(req, res, next)(validationRules, execute);

--- a/functions/src/modules/stpm/tiers/updateTier.ts
+++ b/functions/src/modules/stpm/tiers/updateTier.ts
@@ -18,13 +18,15 @@ export const validationRules: ValidatorObjectRules = {
   rules: {
     sponsorTierName: { rules: ["string"] },
     sponsorTierOrder: { rules: ["number"] },
-    logoSize: { rules: ["string"] }, // TODO: Support Enum Advanced Types
+    logoSize: {
+      rules: [{ type: "enum", rules: ["xs", "sm", "m", "lg", "xl"] }],
+    },
     sponsorshipExpo: { rules: ["boolean"] },
     techTalk: { rules: ["boolean"] },
     officeHours: { rules: ["boolean"] },
     prize: { rules: ["boolean"] },
     prizeBudget: { rules: ["number"] },
-    attendeeData: { rules: ["string"] }, // TODO: Support Enum Advanced Types
+    attendeeData: { rules: [{ type: "enum", rules: ["none", "pre", "post"] }] },
     numberOfMentors: { rules: ["number"] },
     numberOfRecruiters: { rules: ["number"] },
     distributionOfSwag: { rules: ["boolean"] },

--- a/functions/src/modules/stpm/tiers/updateTier.ts
+++ b/functions/src/modules/stpm/tiers/updateTier.ts
@@ -12,29 +12,33 @@ const updateTier: ExpressFunction = (req, res, next) => {
   })(req, res, next);
 };
 
-const validate: ExpressFunction = (req, res, next) => {
-  const validationRules: ValidatorObjectRules = {
-    type: "object",
-    rules: {
-      sponsorTierName: { rules: ["string"] },
-      sponsorTierOrder: { rules: ["number"] },
-      logoSize: { rules: ["string"] }, // TODO: Support Enum Advanced Types
-      sponsorshipExpo: { rules: ["boolean"] },
-      techTalk: { rules: ["boolean"] },
-      officeHours: { rules: ["boolean"] },
-      prize: { rules: ["boolean"] },
-      prizeBudget: { rules: ["number"] },
-      attendeeData: { rules: ["string"] }, // TODO: Support Enum Advanced Types
-      numberOfMentors: { rules: ["number"] },
-      numberOfRecruiters: { rules: ["number"] },
-      distributionOfSwag: { rules: ["boolean"] },
-      openingSessionTalk: { rules: ["boolean"] },
-      openingSessionTalkLength: { rules: ["number"] },
-      closingSessionTalk: { rules: ["boolean"] },
-      closingSessionTalkLength: { rules: ["number"] },
-      // otherBenefits: { [key: string]: string }; // TODO: Support Dictionary Advanced Types
+// Broken out into its own exportable config to be used on the Company endpoints
+export const validationRules: ValidatorObjectRules = {
+  type: "object",
+  rules: {
+    sponsorTierName: { rules: ["string"] },
+    sponsorTierOrder: { rules: ["number"] },
+    logoSize: { rules: ["string"] }, // TODO: Support Enum Advanced Types
+    sponsorshipExpo: { rules: ["boolean"] },
+    techTalk: { rules: ["boolean"] },
+    officeHours: { rules: ["boolean"] },
+    prize: { rules: ["boolean"] },
+    prizeBudget: { rules: ["number"] },
+    attendeeData: { rules: ["string"] }, // TODO: Support Enum Advanced Types
+    numberOfMentors: { rules: ["number"] },
+    numberOfRecruiters: { rules: ["number"] },
+    distributionOfSwag: { rules: ["boolean"] },
+    openingSessionTalk: { rules: ["boolean"] },
+    openingSessionTalkLength: { rules: ["number"] },
+    closingSessionTalk: { rules: ["boolean"] },
+    closingSessionTalkLength: { rules: ["number"] },
+    otherBenefits: {
+      rules: [{ type: "dictionary", rules: ["string", "number"] }],
     },
-  };
+  },
+};
+
+const validate: ExpressFunction = (req, res, next) => {
   requestBodyTypeValidator(req, res, next)(validationRules, execute);
 };
 


### PR DESCRIPTION
- Adds support for empty strings as a separate validation case; fixes #58 .
- Adds support for dictionaries as a separate validation case; fixes #60 .
- Adds support for enums as a separate validation case; fixes #59 .