### PR TITLE
feat(webapp): Create Basic PM UI

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -8,6 +8,7 @@ import LoadingScreen from "./components/misc/LoadingScreen";
 import NotificationBar, {
   NotificationMessage,
 } from "./components/misc/Notifications";
+import PMPages from "./components/modules/pm";
 import STPMPages from "./components/modules/stpm";
 import Error404Page from "./components/pages/Error404Page";
 import Home from "./components/pages/Home";
@@ -45,6 +46,7 @@ const App: React.FunctionComponent<AppProps> = ({ theme, toggleTheme }) => {
             <LoginBox />
           </Route>
           <Route path="/stpm" component={STPMPages} />
+          <Route path="/pm" component={PMPages} />
           <Route component={Error404Page} />
         </Switch>
       </Container>

--- a/webapp/src/components/layouts/LeftMenu.tsx
+++ b/webapp/src/components/layouts/LeftMenu.tsx
@@ -58,7 +58,15 @@ const LeftMenu: React.FunctionComponent<LeftMenuProps> = ({
             { label: "Sponsor Tiers", route: "/stpm/tiers" },
             { label: "Sponsor Companies", route: "/stpm/companies" },
           ]}
-          closeLeftMenu={() => {}}
+          closeLeftMenu={closeLeftMenu}
+        />
+        <MenuItemGroup
+          groupName="Prizes"
+          groupItems={[
+            { label: "Prize Groups", route: "/pm/groups" },
+            { label: "Prize Categories", route: "/pm/categories" },
+          ]}
+          closeLeftMenu={closeLeftMenu}
         />
         <MenuItemGroup
           groupName="Developer Tools"

--- a/webapp/src/components/modules/pm/CategoriesPages.tsx
+++ b/webapp/src/components/modules/pm/CategoriesPages.tsx
@@ -1,0 +1,135 @@
+import { Category } from "@material-ui/icons";
+import React from "react";
+import { Route, Switch } from "react-router-dom";
+import { apiClient } from "../../../helper";
+import CreateDetailEditPage from "../../pages/CreateDetailsEditPage";
+import Error404Page from "../../pages/Error404Page";
+import ListPage from "../../pages/ListPage";
+import PrizesPages from "./PrizesPages";
+
+const CategoriesPages: React.FunctionComponent = () => {
+  const [attributeOptions, setAttributeOptions] = React.useState<
+    {
+      label: string;
+      value: any;
+    }[]
+  >([]);
+  const [loaded, setLoaded] = React.useState<boolean>(false);
+
+  if (!loaded) {
+    setLoaded(true);
+    apiClient
+      .get("stpm/companies")
+      .then((companiesRaw) => {
+        companiesRaw.json().then((companies) => {
+          const companiesTyped = (companies as STPMCompanyList)
+            .sponsorCompanies;
+          setAttributeOptions(
+            companiesTyped.map((company) => {
+              return {
+                label: company.companyName,
+                value: company.companyId,
+              };
+            })
+          );
+        });
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }
+
+  const getCompanyNameFromCompanyId = (id: string) => {
+    for (const company of attributeOptions) {
+      if (company.value === id) {
+        return company.label;
+      }
+    }
+    return "";
+  };
+
+  const listMapFunction = (
+    setListItems: (listItems: GenericListItemInfo[]) => void
+  ) => (schemas: any) => {
+    const schemasTyped = schemas as PMCategoryList;
+    setListItems(
+      schemasTyped.prizeCategories.map((value) => {
+        const prizeSponsor =
+          value.companyId !== undefined
+            ? ` - Sponsored by ${getCompanyNameFromCompanyId(value.companyId)}`
+            : "";
+        return {
+          line1: `${value.prizeCategoryName}${prizeSponsor}`,
+          deleteEndpoint: `pm/categories/${value.prizeCategoryId}`,
+          deleteText: "Delete Prize Category",
+          detailedViewLink: `/pm/categories/category/${value.prizeCategoryId}`,
+          detailedViewText: "Prize Category Details",
+          icon: Category,
+          key: `${value.prizeCategoryId}`,
+          line2: value.prizeCategoryDescription,
+          multiline: true,
+        };
+      })
+    );
+  };
+
+  const PrizeCategoryCreateEditDetailsPageComponent = (
+    <CreateDetailEditPage<PMCategory>
+      objectTypeName={"Prize Category"}
+      listEndpoint="/pm/categories"
+      apiEndpoint={"pm/categories"}
+      idAttribute="prizeCategoryId"
+      attributes={[
+        {
+          attributeName: "prizeCategoryName",
+          attributeLabel: "Prize Category Name",
+        },
+        {
+          attributeName: "prizeCategoryDescription",
+          attributeLabel: "prize Category Description",
+        },
+        {
+          attributeName: "eligibility",
+          attributeLabel: "Eligibility",
+          allowEmptyString: true,
+        },
+        {
+          attributeName: "companyId",
+          attributeLabel: "Sponsor Company",
+          attributeOptions: attributeOptions.concat({
+            label: "None",
+            value: undefined,
+          }),
+        },
+      ]}
+    />
+  );
+
+  return (
+    <Switch>
+      <Route exact path="/pm/categories">
+        <ListPage
+          pageTitle="Prize Categories"
+          objectTypeName="Prize Category"
+          apiEndpoint="pm/categories"
+          createNewLink="/pm/categories/create"
+          listMapFunction={listMapFunction}
+        />
+      </Route>
+      <Route path="/pm/categories/create">
+        {PrizeCategoryCreateEditDetailsPageComponent}
+      </Route>
+      <Route exact path="/pm/categories/category/:prizeCategoryId">
+        {PrizeCategoryCreateEditDetailsPageComponent}
+        <PrizesPages />
+        {/** TODO: Is there a better way to fix this redundancy? */}
+      </Route>
+      <Route path="/pm/categories/category/:prizeCategoryId">
+        <PrizesPages />
+      </Route>
+      <Route component={Error404Page} />
+    </Switch>
+  );
+};
+
+export default CategoriesPages;

--- a/webapp/src/components/modules/pm/GroupsPages.tsx
+++ b/webapp/src/components/modules/pm/GroupsPages.tsx
@@ -51,7 +51,7 @@ const GroupsPages: React.FunctionComponent = () => {
       <Route exact path="/pm/groups">
         <ListPage
           pageTitle="Prize Groups"
-          objectTypeName="Prize Groups"
+          objectTypeName="Prize Group"
           apiEndpoint="pm/groups"
           createNewLink="/pm/groups/create"
           listMapFunction={listMapFunction}

--- a/webapp/src/components/modules/pm/GroupsPages.tsx
+++ b/webapp/src/components/modules/pm/GroupsPages.tsx
@@ -1,0 +1,71 @@
+import { Category } from "@material-ui/icons";
+import React from "react";
+import { Route, Switch } from "react-router-dom";
+import CreateDetailEditPage from "../../pages/CreateDetailsEditPage";
+import Error404Page from "../../pages/Error404Page";
+import ListPage from "../../pages/ListPage";
+
+const GroupsPages: React.FunctionComponent = () => {
+  const listMapFunction = (
+    setListItems: (listItems: GenericListItemInfo[]) => void
+  ) => (schemas: any) => {
+    const schemasTyped = schemas as PMGroupList;
+    setListItems(
+      schemasTyped.prizegroups.map((value) => {
+        return {
+          line1: `${value.prizeGroupName}`,
+          deleteEndpoint: `pm/groups/${value.prizeGroupId}`,
+          deleteText: "Delete Prize Group",
+          detailedViewLink: `/pm/groups/group/${value.prizeGroupId}`,
+          detailedViewText: "Prize Group Details",
+          icon: Category,
+          key: `${value.prizeGroupId}`,
+          line2: value.prizeGroupDescription,
+          multiline: true,
+        };
+      })
+    );
+  };
+
+  const PrizeGroupCreateEditDetailsPageComponent = (
+    <CreateDetailEditPage<PMGroup>
+      objectTypeName={"Prize Group"}
+      listEndpoint="/pm/groups"
+      apiEndpoint={"pm/groups"}
+      idAttribute="prizeGroupId"
+      attributes={[
+        {
+          attributeName: "prizeGroupName",
+          attributeLabel: "Prize Group Name",
+        },
+        {
+          attributeName: "prizeGroupName",
+          attributeLabel: "Prize Group Description",
+        },
+      ]}
+    />
+  );
+
+  return (
+    <Switch>
+      <Route exact path="/pm/groups">
+        <ListPage
+          pageTitle="Prize Groups"
+          objectTypeName="Prize Groups"
+          apiEndpoint="pm/groups"
+          createNewLink="/pm/groups/create"
+          listMapFunction={listMapFunction}
+        />
+      </Route>
+      <Route path="/pm/groups/create">
+        {PrizeGroupCreateEditDetailsPageComponent}
+      </Route>
+      <Route path="/pm/groups/group/:prizeGroupId">
+        {PrizeGroupCreateEditDetailsPageComponent}
+      </Route>
+      <Route component={Error404Page} />
+    </Switch>
+  );
+};
+
+export default GroupsPages;

--- a/webapp/src/components/modules/pm/GroupsPages.tsx
+++ b/webapp/src/components/modules/pm/GroupsPages.tsx
@@ -39,7 +39,7 @@ const GroupsPages: React.FunctionComponent = () => {
           attributeLabel: "Prize Group Name",
         },
         {
-          attributeName: "prizeGroupName",
+          attributeName: "prizeGroupDescription",
           attributeLabel: "Prize Group Description",
         },
       ]}

--- a/webapp/src/components/modules/pm/PrizesPages.tsx
+++ b/webapp/src/components/modules/pm/PrizesPages.tsx
@@ -1,0 +1,95 @@
+import { Category } from "@material-ui/icons";
+import React from "react";
+import { Route, Switch, useParams } from "react-router-dom";
+import CreateDetailEditPage from "../../pages/CreateDetailsEditPage";
+import Error404Page from "../../pages/Error404Page";
+import ListPage from "../../pages/ListPage";
+
+const PrizesPages: React.FunctionComponent = () => {
+  const routeParams = useParams() as any;
+
+  const getPrizeCategoryId = () => {
+    return routeParams.prizeCategoryId as string;
+  };
+
+  const listMapFunction = (
+    setListItems: (listItems: GenericListItemInfo[]) => void
+  ) => (schemas: any) => {
+    const schemasTyped = schemas as PMPrizeList;
+    setListItems(
+      schemasTyped.prizes.map((value) => {
+        return {
+          line1: `${value.prizeDisplayName}`,
+          deleteEndpoint: `pm/categories/${getPrizeCategoryId()}/prizes/${
+            value.prizeId
+          }`,
+          deleteText: "Delete Prize",
+          detailedViewLink: `/pm/categories/category/${getPrizeCategoryId()}/prizes/prize/${
+            value.prizeId
+          }`,
+          detailedViewText: "Prize Details",
+          icon: Category,
+          key: `${value.prizeId}`,
+        };
+      })
+    );
+  };
+
+  const PrizeCreateEditDetailsPageComponent = (
+    <CreateDetailEditPage<PMPrize>
+      objectTypeName={"Prize"}
+      listEndpoint={`/pm/categories/category/${getPrizeCategoryId()}`}
+      apiEndpoint={`pm/categories/${getPrizeCategoryId()}/prizes/`}
+      idAttribute="prizeId"
+      attributes={[
+        {
+          attributeName: "prizeDisplayName",
+          attributeLabel:
+            "Prize Display Name (the name of the prize to display on the live site)",
+        },
+        {
+          attributeName: "prizeListingName",
+          attributeLabel:
+            "Prize Listing Name (the name of the product on the site selling it)",
+        },
+        {
+          attributeName: "prizePrice",
+          attributeLabel: "Prize Price (USD)",
+          attributeTypeIsNumber: true,
+        },
+        {
+          attributeName: "prizeUrl",
+          attributeLabel: "Prize Link (to the site selling the prize)",
+        },
+        {
+          attributeName: "prizeASIN",
+          attributeLabel:
+            "Prize Id (the product id from the site selling it; i.e. the ASIN number on Amazon)",
+        },
+      ]}
+    />
+  );
+
+  return (
+    <Switch>
+      <Route exact path="/pm/categories/category/:prizeCategoryId">
+        <ListPage
+          pageTitle="Prizes"
+          objectTypeName="Prize"
+          apiEndpoint={`pm/categories/${getPrizeCategoryId()}/prizes/`}
+          createNewLink={`/pm/categories/category/${getPrizeCategoryId()}/prizes/create`}
+          listMapFunction={listMapFunction}
+        />
+      </Route>
+      <Route path="/pm/categories/category/:prizeCategoryId/prizes/create">
+        {PrizeCreateEditDetailsPageComponent}
+      </Route>
+      <Route path="/pm/categories/category/:prizeCategoryId/prizes/prize/:prizeId">
+        {PrizeCreateEditDetailsPageComponent}
+      </Route>
+      <Route component={Error404Page} />
+    </Switch>
+  );
+};
+
+export default PrizesPages;

--- a/webapp/src/components/modules/pm/index.tsx
+++ b/webapp/src/components/modules/pm/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Route, Switch } from "react-router-dom";
+import Error404Page from "../../pages/Error404Page";
+import CategoriesPages from "./CategoriesPages";
+import GroupsPages from "./GroupsPages";
+
+const PMPages: React.FunctionComponent = () => {
+  return (
+    <Switch>
+      <Route path="/pm/categories" component={CategoriesPages} />
+      <Route path="/pm/groups" component={GroupsPages} />
+      <Route component={Error404Page} />
+    </Switch>
+  );
+};
+
+export default PMPages;

--- a/webapp/src/components/modules/stpm/CompaniesPages.tsx
+++ b/webapp/src/components/modules/stpm/CompaniesPages.tsx
@@ -107,7 +107,7 @@ const CompaniesPages: React.FunctionComponent = () => {
       <Route path="/stpm/companies/create">
         {CompanyCreateEditDetailsPageComponent}
       </Route>
-      <Route path="/stpm/companies/company/:id">
+      <Route path="/stpm/companies/company/:companyId">
         {CompanyCreateEditDetailsPageComponent}
       </Route>
       <Route component={Error404Page} />

--- a/webapp/src/components/modules/stpm/TiersPages.tsx
+++ b/webapp/src/components/modules/stpm/TiersPages.tsx
@@ -131,7 +131,7 @@ const TiersPages: React.FunctionComponent = () => {
       <Route path="/stpm/tiers/create">
         {TierCreateEditDetailsPageComponent}
       </Route>
-      <Route path="/stpm/tiers/tier/:id">
+      <Route path="/stpm/tiers/tier/:sponsorTierId">
         {TierCreateEditDetailsPageComponent}
       </Route>
       <Route component={Error404Page} />

--- a/webapp/src/components/pages/CreateDetailsEditPage.tsx
+++ b/webapp/src/components/pages/CreateDetailsEditPage.tsx
@@ -26,7 +26,8 @@ const CreateDetailEditPage /*: React.FunctionComponent<CreateDetailEditPageProps
 }: CreateDetailEditPageProps<ObjectType> & { children?: ReactNode }) => {
   const routeParams = useParams() as any;
   const routeHistory = useHistory();
-  const id = routeParams.id !== "create" ? routeParams.id : "";
+  const id =
+    routeParams[idAttribute] !== "create" ? routeParams[idAttribute] : "";
 
   const [object, setObject] = React.useState<ObjectType | undefined>();
   const [updateObject, setUpdateObject] = React.useState<Partial<ObjectType>>();


### PR DESCRIPTION
Closes #34 
Closes #36 
Closes #38

Note: also uses the `idAttribute` instead of just a general `id` in the `CreateDetailsEditPage` to allow for nesting.